### PR TITLE
fix: double click on back button in TopBar call popBackState twice

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ext/NavControllerExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/NavControllerExt.kt
@@ -1,0 +1,11 @@
+package me.mudkip.moememos.ext
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.NavController
+
+fun NavController.popBackStackIfLifecycleIsResumed(lifecycleOwner: LifecycleOwner? = null) {
+    if (lifecycleOwner?.lifecycle?.currentState === Lifecycle.State.RESUMED) {
+        popBackStack()
+    }
+}

--- a/app/src/main/java/me/mudkip/moememos/ui/page/memoinput/MemoInputPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memoinput/MemoInputPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -41,6 +42,7 @@ import me.mudkip.moememos.data.constant.LIST_ITEM_SYMBOL_LIST
 import me.mudkip.moememos.data.model.MemosVisibility
 import me.mudkip.moememos.data.model.ShareContent
 import me.mudkip.moememos.ext.icon
+import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ext.suspendOnErrorMessage
 import me.mudkip.moememos.ext.titleResource
@@ -64,6 +66,7 @@ fun MemoInputPage(
     val coroutineScope = rememberCoroutineScope()
     val snackbarState = remember { SnackbarHostState() }
     val navController = LocalRootNavController.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val memosViewModel = LocalMemos.current
     val memo = remember { memosViewModel.memos.toList().find { it.id == memoId } }
     var text by rememberSaveable(stateSaver = TextFieldValue.Saver) {
@@ -204,7 +207,7 @@ fun MemoInputPage(
                 },
                 navigationIcon = {
                     IconButton(onClick = {
-                        navController.popBackStack()
+                        navController.popBackStackIfLifecycleIsResumed(lifecycleOwner)
                     }) {
                         Icon(Icons.Filled.Close, contentDescription = R.string.close.string)
                     }

--- a/app/src/main/java/me/mudkip/moememos/ui/page/memos/SearchPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memos/SearchPage.kt
@@ -10,10 +10,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import me.mudkip.moememos.R
+import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ui.page.common.LocalRootNavController
 
@@ -25,6 +27,7 @@ fun SearchPage() {
     }
 
     val rootNavController = LocalRootNavController.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val focusRequester = remember { FocusRequester() }
 
     Scaffold(
@@ -42,7 +45,7 @@ fun SearchPage() {
                         placeholder = { Text(R.string.search.string) },
                         shape = ShapeDefaults.ExtraLarge,
                         leadingIcon = {
-                            IconButton(onClick = { rootNavController.popBackStack() }) {
+                            IconButton(onClick = { rootNavController.popBackStackIfLifecycleIsResumed(lifecycleOwner) }) {
                                 Icon(
                                     Icons.AutoMirrored.Outlined.ArrowBack,
                                     contentDescription = R.string.back.string

--- a/app/src/main/java/me/mudkip/moememos/ui/page/resource/ResourceListPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/resource/ResourceListPage.kt
@@ -19,11 +19,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import me.mudkip.moememos.R
 import me.mudkip.moememos.ext.string
+import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
 import me.mudkip.moememos.ui.component.MemoImage
 import me.mudkip.moememos.viewmodel.LocalUserState
 import me.mudkip.moememos.viewmodel.ResourceListViewModel
@@ -34,13 +36,15 @@ fun ResourceListPage(
     navController: NavHostController,
     viewModel: ResourceListViewModel = hiltViewModel()
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(text = R.string.resources.string) },
                 navigationIcon = {
                     IconButton(onClick = {
-                        navController.popBackStack()
+                        navController.popBackStackIfLifecycleIsResumed(lifecycleOwner)
                     }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = R.string.back.string)
                     }

--- a/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
@@ -32,12 +32,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.launch
 import me.mudkip.moememos.R
 import me.mudkip.moememos.ext.string
+import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
 import me.mudkip.moememos.ui.page.common.RouteName
 import me.mudkip.moememos.viewmodel.LocalUserState
 
@@ -48,6 +50,7 @@ fun SettingsPage(
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val userStateViewModel = LocalUserState.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
     val uriHandler = LocalUriHandler.current
     val status = userStateViewModel.status
@@ -60,7 +63,7 @@ fun SettingsPage(
                 title = { Text(text = R.string.settings.string) },
                 navigationIcon = {
                     IconButton(onClick = {
-                        navController.popBackStack()
+                        navController.popBackStackIfLifecycleIsResumed(lifecycleOwner)
                     }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = R.string.back.string)
                     }


### PR DESCRIPTION
## Problem being fixed

When clicking the BackIcon in the TopBar of a secondary page (e.g. MemoInputPage, SettingsPage, etc.) twice quickly, `navController.popBackStack` is called twice as well, which results in both the current page and the previous one being popped, and only a blank page is left.

https://github.com/mudkipme/MoeMemosAndroid/assets/32296555/c07a5021-a3a9-49f5-b851-8f09386c22cb

## Details

Add following code in [MemoInputPage.kt](https://github.com/mudkipme/MoeMemosAndroid/blob/fbf72d2feab799f361f25cdf893e53b758213508/app/src/main/java/me/mudkip/moememos/ui/page/memoinput/MemoInputPage.kt#L205-L211) to print some debug logs:

```diff
+   val lifecycleOwner = LocalLifecycleOwner.current
    // ...
                navigationIcon = {
                    IconButton(onClick = {
+                       Log.d("MemosDebug", "- navigationIconButton onClick")
+                       Log.d("MemosDebug", "[popBackStack before] route=${navController.currentBackStackEntry?.destination?.route}; lifecycle.currentState=${lifecycleOwner?.lifecycle?.currentState}")
                        navController.popBackStack()
+                       Log.d("MemosDebug", "[popBackStack after] route=${navController.currentBackStackEntry?.destination?.route}; lifecycle.currentState=${lifecycleOwner?.lifecycle?.currentState}")
                    }) {
                        Icon(Icons.Filled.Close, contentDescription = R.string.close.string)
                    }
                },
```

Clicking on the BackIcon twice quickly in the MemoInputPage, MoeMemos prints the following debug logs:

```
01-05 15:05:41.957 17263 17263 D MemosDebug: - navigationIconButton onClick
01-05 15:05:41.957 17263 17263 D MemosDebug: [popBackStack before] route=input; lifecycle.currentState=RESUMED
01-05 15:05:41.960 17263 17263 D MemosDebug: [popBackStack after] route=memos; lifecycle.currentState=CREATED
01-05 15:05:42.173 17263 17263 D MemosDebug: - navigationIconButton onClick
01-05 15:05:42.173 17263 17263 D MemosDebug: [popBackStack before] route=memos; lifecycle.currentState=CREATED
01-05 15:05:42.175 17263 17263 D MemosDebug: [popBackStack after] route=null; lifecycle.currentState=CREATED
```

It's confirmed that both two pages in the back stack are popped.

## Changes to fix this problem

Once popBackStack trigger a navigation, the lifecycle state of current page will be changed from `RESUMED` to other downward states, so we should check `LocalLifecycleOwner.current.lifecycle.currentState === Lifecycle.State.RESUMED` before calling `navController.popBackStack`

```diff
+ val lifecycleOwner = LocalLifecycleOwner.current
+ if (lifecycleOwner?.lifecycle?.currentState === Lifecycle.State.RESUMED) {
    navController.popBackStack()
+ }
```

**References**

1. https://github.com/android/compose-samples/blob/081721ad44dfb29b55b1bc34f83d693b6b8dc9dd/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackAppState.kt#L141-L147
2. https://github.com/google/accompanist/issues/1320
