### PR TITLE
Feat: support drag and drop

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemoContent.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemoContent.kt
@@ -1,6 +1,7 @@
 package me.mudkip.moememos.ui.component
 
 import android.net.Uri
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -118,10 +119,10 @@ fun MemoContent(
                 colors = AssistChipDefaults.assistChipColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                 ),
-                border = AssistChipDefaults.assistChipBorder(
-                    borderColor = MaterialTheme.colorScheme.primaryContainer,
-                    borderWidth = 0.dp,
-                ),
+                border = BorderStroke(
+                    width = 0.dp,
+                    color = MaterialTheme.colorScheme.primaryContainer
+                )
             )
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
         // https://developer.android.com/jetpack/androidx/releases/compose-ui
-        compose_version = '1.5.1'
+        compose_version = '1.6.6'
         // https://github.com/google/accompanist/releases
         accompanist = '0.32.0'
         // https://developer.android.com/jetpack/androidx/releases/compose-material3
-        material3 = '1.2.0-alpha07'
+        material3 = '1.2.1'
         // https://square.github.io/okhttp/changelogs/changelog/
         okhttp_version = '4.11.0'
         // https://github.com/square/retrofit/tags


### PR DESCRIPTION
Some customized Android systems, such as Huawei's Harmony OS, provide a system-level pasteboard, which can cache content copied multiple times and save each copy in the form of blocks. Applications can capture the contents of the pasteboard by implementing `Modifier.dragAndDropTarget`.

In my implementation, different blocks in this system-wide pasteboard are separated by a blank line and pasted into MoeMemos.

Of course, this system-level pasteboard also supports images, which I will implement in subsequent PRs.

To support `Modifier.dragAndDropTarget`, I update compose and material 3 versions.

https://github.com/mudkipme/MoeMemosAndroid/assets/1697504/58c5bac3-0ac8-4f73-ab24-5f4653d8bddd

Ref: 
- https://developer.android.com/reference/kotlin/androidx/compose/foundation/draganddrop/package-summary
- https://canopas.com/how-to-drag-and-drop-using-modifier-drag-and-drop-source-target-jetpack-compose