### PR TITLE
Blockquote support

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
@@ -209,7 +209,7 @@ fun AnnotatedString.Builder.appendMarkdown(
         MarkdownElementTypes.ATX_2,
         MarkdownElementTypes.SETEXT_2,
         MarkdownElementTypes.ATX_3 -> {
-            var content = node.children.find { it.type == MarkdownTokenTypes.ATX_CONTENT || it.type == MarkdownTokenTypes.SETEXT_CONTENT }
+            val content = node.children.find { it.type == MarkdownTokenTypes.ATX_CONTENT || it.type == MarkdownTokenTypes.SETEXT_CONTENT }
 
             val textStyle = when (node.type) {
                 MarkdownElementTypes.ATX_1, MarkdownElementTypes.SETEXT_1 -> headlineLarge
@@ -301,10 +301,8 @@ fun AnnotatedString.Builder.appendMarkdown(
             val borderColor = Color.Gray
             val quotePadding = 16.sp
 
-            // Iterate over each child node of the block quote
             node.children.forEach { childNode ->
                 if (childNode.type != MarkdownTokenTypes.BLOCK_QUOTE) {
-                    // Build the content of the block quote
                     val quoteContent = buildAnnotatedString {
                         appendMarkdown(
                             markdownText = markdownText,

--- a/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
@@ -1,7 +1,6 @@
 package me.mudkip.moememos.ext
 
 import androidx.compose.foundation.text.appendInlineContent
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -9,6 +8,7 @@ import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.UrlAnnotation
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -297,15 +297,15 @@ fun AnnotatedString.Builder.appendMarkdown(
         }
 
         MarkdownElementTypes.BLOCK_QUOTE -> {
-            withStyle(
-                style = ParagraphStyle(textIndent = TextIndent(firstLine = 16.sp))
-            ) {
-                withStyle(
-                    style = SpanStyle(
-                        background = lightColorScheme().surfaceDim,
-                    )
-                ) {
-                    node.children.forEach { childNode ->
+            val quoteColor = Color.Black.copy(alpha = 0.7f)
+            val borderColor = Color.Gray
+            val quotePadding = 16.sp
+
+            // Iterate over each child node of the block quote
+            node.children.forEach { childNode ->
+                if (childNode.type != MarkdownTokenTypes.BLOCK_QUOTE) {
+                    // Build the content of the block quote
+                    val quoteContent = buildAnnotatedString {
                         appendMarkdown(
                             markdownText = markdownText,
                             node = childNode,
@@ -319,6 +319,17 @@ fun AnnotatedString.Builder.appendMarkdown(
                             headlineMedium = headlineMedium,
                             headlineSmall = headlineSmall
                         )
+                    }
+                    val lines = quoteContent.split("\n")
+                    lines.forEachIndexed { index, line ->
+                        if (index > 0) append("\n")
+                        withStyle(style = ParagraphStyle(textIndent = TextIndent(firstLine = 16.sp, restLine = quotePadding))) {
+                            withStyle(style = SpanStyle(color = borderColor)) {
+                            }
+                            withStyle(style = SpanStyle(color = quoteColor)) {
+                                append(line)
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/AnnotatedStringExt.kt
@@ -1,6 +1,7 @@
 package me.mudkip.moememos.ext
 
 import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -12,6 +13,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.text.withAnnotation
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
@@ -294,6 +296,33 @@ fun AnnotatedString.Builder.appendMarkdown(
             }
         }
 
+        MarkdownElementTypes.BLOCK_QUOTE -> {
+            withStyle(
+                style = ParagraphStyle(textIndent = TextIndent(firstLine = 16.sp))
+            ) {
+                withStyle(
+                    style = SpanStyle(
+                        background = lightColorScheme().surfaceDim,
+                    )
+                ) {
+                    node.children.forEach { childNode ->
+                        appendMarkdown(
+                            markdownText = markdownText,
+                            node = childNode,
+                            depth = depth + 1,
+                            linkColor = linkColor,
+                            onImage = onImage,
+                            onCheckbox = onCheckbox,
+                            maxWidth = maxWidth,
+                            bulletColor = bulletColor,
+                            headlineLarge = headlineLarge,
+                            headlineMedium = headlineMedium,
+                            headlineSmall = headlineSmall
+                        )
+                    }
+                }
+            }
+        }
         else -> {
             append(node.getTextInNode(markdownText).toString())
         }


### PR DESCRIPTION
Adds initial support for markdown blockquotes using ">". Lines with ">" at the beginning are now correctly parsed. The greater than sign is now not shown anymore in the note view after editing and the blockquote is now styled as an indented block, with slightly lower alpha value, setting it apart from regular text.

Further styling for more eyecandy might be great in the future, but probably needs more rework, as this involves implementing stuff via composables because a) the function for markdown parsing is not a composable and b) without composable the styling of the text itself is limited within the ui as far as I know.

Solves #165 

![WhatsApp Image 2024-08-07 at 16 25 43](https://github.com/user-attachments/assets/d9db0126-8dcb-404a-9912-711b4bf92b4a)