### PR TITLE
Memo exit dialogue

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ui/page/memoinput/MemoInputPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memoinput/MemoInputPage.kt
@@ -108,6 +108,7 @@ fun MemoInputPage(
     val lifecycleOwner = LocalLifecycleOwner.current
     val memosViewModel = LocalMemos.current
     val memo = remember { memosViewModel.memos.toList().find { it.identifier == memoIdentifier } }
+    var initialContent by remember { mutableStateOf(memo?.content ?: "") }
     var text by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(memo?.content ?: "", TextRange(memo?.content?.length ?: 0)))
     }
@@ -147,7 +148,7 @@ fun MemoInputPage(
     }
 
     fun handleExit() {
-        if (text.text.isNotEmpty()) {
+        if (text.text.isNotEmpty() && text.text != initialContent) {
             showExitConfirmation = true
         } else {
             navController.popBackStackIfLifecycleIsResumed(lifecycleOwner)
@@ -513,6 +514,7 @@ fun MemoInputPage(
         when {
             memo != null -> {
                 viewModel.uploadResources.addAll(memo.resources)
+                initialContent = memo.content
             }
 
             shareContent != null -> {


### PR DESCRIPTION
As per #158 I added a confirmation dialogue when exiting a note via the close button or back gesture/button. @mudkipme let me know if you prefer the behaviour to be auto-save on exit, like it is implemented in e.g. Google Keep. I can update the PR accordingly

![Screen_recording_20240816_221955](https://github.com/user-attachments/assets/a8d11265-53d5-44f7-9084-e030b8a96e8f)
