### PR TITLE
feat: add expand fab animation when scrolling

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosHomePage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosHomePage.kt
@@ -1,5 +1,6 @@
 package me.mudkip.moememos.ui.page.memos
 
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Menu
@@ -13,6 +14,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.launch
@@ -27,8 +31,16 @@ fun MemosHomePage(
     drawerState: DrawerState? = null,
     navController: NavHostController
 ) {
+    val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val rootNavController = LocalRootNavController.current
+
+    val expandedFab by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex == 0
+        }
+    }
+
 
     Scaffold(
         topBar = {
@@ -56,6 +68,7 @@ fun MemosHomePage(
                 onClick = {
                     rootNavController.navigate(RouteName.INPUT)
                 },
+                expanded = expandedFab,
                 text = { Text(R.string.new_memo.string) },
                 icon = { Icon(Icons.Filled.Add, contentDescription = R.string.compose.string) }
             )
@@ -63,6 +76,7 @@ fun MemosHomePage(
 
         content = { innerPadding ->
             MemosList(
+                lazyListState = listState,
                 contentPadding = innerPadding
             )
         }

--- a/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,6 +26,7 @@ import timber.log.Timber
 @Composable
 fun MemosList(
     contentPadding: PaddingValues,
+    lazyListState: LazyListState = rememberLazyListState(),
     tag: String? = null,
     searchString: String? = null
 ) {
@@ -53,11 +55,10 @@ fun MemosList(
 
         fullList
     }
-    val lazyListState = rememberLazyListState()
     var listTopId: String? by rememberSaveable {
         mutableStateOf(null)
     }
-    
+
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = {


### PR DESCRIPTION
This pull request introduces an expandable Floating Action Button (FAB) that adjusts its size as the user scrolls through the memos.

The expandable FAB improves the user interface by minimizing unnecessary screen space usage, providing more room for users to view their content.

The FAB shrinks when the user scrolls past the first item in the lazy list and expands back when the first item becomes visible again. We can also implement additional behaviors, such as expanding the FAB when the user scrolls up and shrinking it when scrolling down (similar to the behavior in Gmail). I welcome any feedback and am happy to make any adjustments!

### Video Recording 


https://github.com/user-attachments/assets/1cb441d6-478e-40bf-bbd6-51cb6fd55346
