### PR TITLE
fix: prevent slashes in resource names from being encoded

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/data/api/MemosV1Api.kt
+++ b/app/src/main/java/me/mudkip/moememos/data/api/MemosV1Api.kt
@@ -150,8 +150,12 @@ data class MemosV1Resource(
         if (externalLink.isNotEmpty()) {
             return Uri.parse(externalLink)
         }
-        return Uri.parse(host)
-            .buildUpon().appendPath("file").appendPath(name).appendPath(filename).build()
+
+        return Uri.parse(host).buildUpon().apply {
+            appendPath("file")
+            name.split("/").forEach { path -> appendPath(path) }
+            appendPath(filename)
+        }.build()
     }
 }
 


### PR DESCRIPTION
Hello, 
this should fix issue #239, so images can be fetched from the correct source.
