### PR TITLE
Initial Widget Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ lint/tmp/
 
 # Kotlin 2.0
 .kotlin/
+
+.clinerules

--- a/.justfile
+++ b/.justfile
@@ -1,0 +1,43 @@
+# Justfile for MoeMemosAndroid
+# https://github.com/casey/just
+
+# List available commands
+default:
+    @just --list
+
+# Build the project
+build:
+    ./gradlew build
+
+# Build without running lint checks
+build-no-lint:
+    ./gradlew build -x lint
+
+# Run the app on a connected device or emulator
+dev:
+    ./gradlew installDebug
+
+# Run lint checks
+lint:
+    ./gradlew lint
+
+# Clean the project
+clean:
+    ./gradlew clean
+
+# Run tests
+test:
+    ./gradlew test
+
+# Build and run the app
+run: build-no-lint dev
+    @echo "App built and installed"
+
+# Create a release build
+release:
+    ./gradlew assembleRelease
+
+# Generate APK
+apk:
+    ./gradlew assembleDebug
+    @echo "APK generated at app/build/outputs/apk/debug/app-debug.apk"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,12 @@ dependencies {
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "androidx.datastore:datastore-preferences-core:1.0.0"
+    
+    // Glance for App Widget
+    implementation "androidx.glance:glance:1.0.0"
+    implementation "androidx.glance:glance-appwidget:1.0.0"
+    implementation "androidx.glance:glance-material3:1.0.0"
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
 }
 
 protobuf {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,18 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+        
+        <!-- Widget Receiver -->
+        <receiver
+            android:name=".widget.MoeMemosGlanceWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/moe_memos_glance_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/me/mudkip/moememos/MainActivity.kt
+++ b/app/src/main/java/me/mudkip/moememos/MainActivity.kt
@@ -1,5 +1,6 @@
 package me.mudkip.moememos
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,6 +19,12 @@ class MainActivity : ComponentActivity() {
     private val userStateViewModel: UserStateViewModel by viewModels()
     private val memosViewModel: MemosViewModel by viewModels()
 
+    companion object {
+        const val ACTION_NEW_MEMO = "me.mudkip.moememos.action.NEW_MEMO"
+        const val ACTION_EDIT_MEMO = "me.mudkip.moememos.action.EDIT_MEMO"
+        const val EXTRA_MEMO_ID = "memoId"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -29,5 +36,10 @@ class MainActivity : ComponentActivity() {
                 Navigation()
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 }

--- a/app/src/main/java/me/mudkip/moememos/data/repository/LocalDatabaseRepository.kt
+++ b/app/src/main/java/me/mudkip/moememos/data/repository/LocalDatabaseRepository.kt
@@ -182,7 +182,7 @@ class LocalDatabaseRepository(
         }
     }
 
-    override suspend fun logout(): ApiResponse<Unit> {
+    suspend fun logout(): ApiResponse<Unit> {
         return try {
             userPreferences.saveUser("local", "Local User")
             ApiResponse.Success(Unit)

--- a/app/src/main/java/me/mudkip/moememos/ui/page/common/Navigation.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/common/Navigation.kt
@@ -23,6 +23,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import me.mudkip.moememos.MainActivity
 import me.mudkip.moememos.data.model.ShareContent
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ext.suspendOnNotLogin
@@ -124,6 +125,15 @@ fun Navigation() {
                 when (intent.getStringExtra("action")) {
                     "compose" -> navController.navigate(RouteName.INPUT)
                     "search" -> navController.navigate(RouteName.SEARCH)
+                }
+            }
+            MainActivity.ACTION_NEW_MEMO -> {
+                navController.navigate(RouteName.INPUT)
+            }
+            MainActivity.ACTION_EDIT_MEMO -> {
+                val memoId = intent.getStringExtra(MainActivity.EXTRA_MEMO_ID)
+                if (memoId != null) {
+                    navController.navigate("${RouteName.EDIT}?memoId=$memoId")
                 }
             }
         }

--- a/app/src/main/java/me/mudkip/moememos/viewmodel/MemoInputViewModel.kt
+++ b/app/src/main/java/me/mudkip/moememos/viewmodel/MemoInputViewModel.kt
@@ -1,9 +1,10 @@
 package me.mudkip.moememos.viewmodel
 
+import android.app.Application
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.compose.runtime.mutableStateListOf
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.skydoves.sandwich.ApiResponse
 import com.skydoves.sandwich.suspendOnSuccess
@@ -18,6 +19,7 @@ import me.mudkip.moememos.data.model.MemoVisibility
 import me.mudkip.moememos.data.model.Resource
 import me.mudkip.moememos.data.service.MemoService
 import me.mudkip.moememos.ext.settingsDataStore
+import me.mudkip.moememos.widget.WidgetUpdater
 import okhttp3.MediaType.Companion.toMediaType
 import java.io.ByteArrayOutputStream
 import java.util.UUID
@@ -26,20 +28,31 @@ import javax.inject.Inject
 @HiltViewModel
 class MemoInputViewModel @Inject constructor(
     @ApplicationContext
-    private val context: Context,
+    application: Context,
     private val memoService: MemoService
-) : ViewModel() {
+) : AndroidViewModel(application as Application) {
+    private val context = application
     val draft = context.settingsDataStore.data.map { settings ->
         settings.usersList.firstOrNull { it.accountKey == settings.currentUser }?.settings?.draft
     }
     var uploadResources = mutableStateListOf<Resource>()
 
     suspend fun createMemo(content: String, visibility: MemoVisibility, tags: List<String>): ApiResponse<Memo> = withContext(viewModelScope.coroutineContext) {
-        memoService.repository.createMemo(content, visibility, uploadResources, tags)
+        val response = memoService.repository.createMemo(content, visibility, uploadResources, tags)
+        // Update widgets when a new memo is created
+        response.suspendOnSuccess {
+            WidgetUpdater.updateWidgets(getApplication())
+        }
+        response
     }
 
     suspend fun editMemo(identifier: String, content: String, visibility: MemoVisibility, tags: List<String>): ApiResponse<Memo> = withContext(viewModelScope.coroutineContext) {
-        memoService.repository.updateMemo(identifier, content, uploadResources, visibility, tags)
+        val response = memoService.repository.updateMemo(identifier, content, uploadResources, visibility, tags)
+        // Update widgets when a memo is edited
+        response.suspendOnSuccess {
+            WidgetUpdater.updateWidgets(getApplication())
+        }
+        response
     }
 
     fun updateDraft(content: String) = runBlocking {

--- a/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
@@ -38,6 +38,7 @@ import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import com.skydoves.sandwich.ApiResponse
 import com.skydoves.sandwich.suspendOnSuccess
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
@@ -81,9 +82,11 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
                                 .thenByDescending { it.date }
                         ).take(3)
                         memos = sortedMemos
+                        error = null
                     }
                 } catch (e: Exception) {
-                    error = e.message
+                    error = e.message ?: "Unknown error"
+                    android.util.Log.e("MoeMemosWidget", "Exception in widget", e)
                 } finally {
                     isLoading = false
                 }
@@ -172,11 +175,11 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
                 }
                 else -> {
                     Column(
-                        modifier = GlanceModifier.fillMaxSize()
+                        modifier = GlanceModifier.fillMaxSize(),
                     ) {
                         memos.forEach { memo ->
                             MemoItem(context, memo)
-                            Spacer(modifier = GlanceModifier.height(8.dp))
+                            Spacer(modifier = GlanceModifier.height(4.dp))
                         }
                     }
                 }
@@ -190,7 +193,7 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
         Box(
             modifier = GlanceModifier
                 .fillMaxWidth()
-                .padding(horizontal = 15.dp, vertical = 8.dp)
+                .padding(horizontal = 4.dp, vertical = 4.dp)
         ) {
             // Card content with rounded corners
             Column(

--- a/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
@@ -1,0 +1,299 @@
+package me.mudkip.moememos.widget
+
+import android.content.Context
+import android.content.Intent
+import android.text.format.DateUtils
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.skydoves.sandwich.suspendOnSuccess
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.mudkip.moememos.MainActivity
+import me.mudkip.moememos.R
+import me.mudkip.moememos.data.model.Memo
+import me.mudkip.moememos.data.service.MemoService
+import me.mudkip.moememos.ext.string
+import java.time.Instant
+
+class MoeMemosGlanceWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val widgetEntryPoint = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            WidgetEntryPoint::class.java
+        )
+        val memoService = widgetEntryPoint.memoService()
+        
+        provideContent {
+            GlanceTheme {
+                WidgetContent(context, memoService)
+            }
+        }
+    }
+
+    @Composable
+    private fun WidgetContent(context: Context, memoService: MemoService) {
+        var memos by remember { mutableStateOf<List<Memo>>(emptyList()) }
+        var isLoading by remember { mutableStateOf(true) }
+        var error by remember { mutableStateOf<String?>(null) }
+
+        LaunchedEffect(Unit) {
+            withContext(Dispatchers.IO) {
+                try {
+                    memoService.repository.listMemos().suspendOnSuccess {
+                        // Get pinned memos first, then most recent
+                        val sortedMemos = data.sortedWith(
+                            compareByDescending<Memo> { it.pinned }
+                                .thenByDescending { it.date }
+                        ).take(3)
+                        memos = sortedMemos
+                    }
+                } catch (e: Exception) {
+                    error = e.message
+                } finally {
+                    isLoading = false
+                }
+            }
+        }
+
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.background)
+                .padding(16.dp)
+        ) {
+            // Header
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // App icon
+                Image(
+                    provider = ImageProvider(R.mipmap.ic_launcher),
+                    contentDescription = null,
+                    modifier = GlanceModifier.size(24.dp)
+                )
+                Spacer(modifier = GlanceModifier.width(8.dp))
+                Text(
+                    text = context.getString(R.string.memos),
+                    style = TextStyle(
+                        color = GlanceTheme.colors.primary,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+                Spacer(modifier = GlanceModifier.defaultWeight())
+                // Add new memo button
+                Box(
+                    modifier = GlanceModifier
+                        .size(36.dp)
+                        .clickable(actionRunCallback<AddNewMemoAction>())
+                        .padding(4.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        provider = ImageProvider(R.drawable.ic_shortcut_add),
+                        contentDescription = context.getString(R.string.edit),
+                        modifier = GlanceModifier.size(24.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = GlanceModifier.height(8.dp))
+
+            // Content
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = GlanceModifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = context.getString(R.string.loading),
+                            style = TextStyle(color = GlanceTheme.colors.onBackground)
+                        )
+                    }
+                }
+                error != null -> {
+                    Box(
+                        modifier = GlanceModifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = error ?: context.getString(R.string.error_unknown),
+                            style = TextStyle(color = GlanceTheme.colors.error)
+                        )
+                    }
+                }
+                memos.isEmpty() -> {
+                    Box(
+                        modifier = GlanceModifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = context.getString(R.string.no_memos),
+                            style = TextStyle(color = GlanceTheme.colors.onBackground)
+                        )
+                    }
+                }
+                else -> {
+                    Column(
+                        modifier = GlanceModifier.fillMaxSize()
+                    ) {
+                        memos.forEach { memo ->
+                            MemoItem(context, memo)
+                            Spacer(modifier = GlanceModifier.height(8.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun MemoItem(context: Context, memo: Memo) {
+        // Card-like container with rounded corners
+        Box(
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .padding(horizontal = 15.dp, vertical = 8.dp)
+        ) {
+            // Card content with rounded corners
+            Column(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .background(
+                        ImageProvider(
+                            if (memo.pinned) R.drawable.widget_card_pinned_background 
+                            else R.drawable.widget_card_background
+                        )
+                    )
+                    .clickable(actionRunCallback<OpenMemoAction>(
+                        actionParametersOf(
+                            OpenMemoAction.MEMO_ID to memo.identifier
+                        )
+                    ))
+                    .padding(16.dp)
+            ) {
+                // Memo header
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = GlanceModifier.fillMaxWidth()
+                ) {
+                    // Date
+                    Text(
+                        text = DateUtils.getRelativeTimeSpanString(
+                            memo.date.toEpochMilli(),
+                            Instant.now().toEpochMilli(),
+                            DateUtils.MINUTE_IN_MILLIS
+                        ).toString(),
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurfaceVariant,
+                            fontSize = 12.sp
+                        )
+                    )
+                    
+                    // Add a lock icon for visibility (similar to the screenshot)
+                    Spacer(modifier = GlanceModifier.width(4.dp))
+                    Image(
+                        provider = ImageProvider(android.R.drawable.ic_lock_lock),
+                        contentDescription = "Private",
+                        modifier = GlanceModifier.size(14.dp)
+                    )
+                    
+                    // Pinned indicator
+                    if (memo.pinned) {
+                        Spacer(modifier = GlanceModifier.width(4.dp))
+                        Image(
+                            provider = ImageProvider(R.drawable.ic_pin),
+                            contentDescription = "Pinned",
+                            modifier = GlanceModifier.size(14.dp)
+                        )
+                    }
+                    
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+                }
+                
+                Spacer(modifier = GlanceModifier.height(8.dp))
+                
+                // Memo content
+                Text(
+                    text = memo.content.take(100) + if (memo.content.length > 100) "..." else "",
+                    style = TextStyle(
+                        color = GlanceTheme.colors.onSurface,
+                        fontSize = 14.sp
+                    ),
+                    maxLines = 3
+                )
+            }
+        }
+    }
+}
+
+class AddNewMemoAction : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters
+    ) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_NEW_MEMO
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        context.startActivity(intent)
+    }
+}
+
+class OpenMemoAction : ActionCallback {
+    companion object {
+        val MEMO_ID = ActionParameters.Key<String>("memo_id")
+    }
+
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters
+    ) {
+        val memoId = parameters[MEMO_ID] ?: return
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_EDIT_MEMO
+            putExtra(MainActivity.EXTRA_MEMO_ID, memoId)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidgetReceiver.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidgetReceiver.kt
@@ -1,0 +1,66 @@
+package me.mudkip.moememos.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class MoeMemosGlanceWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = MoeMemosGlanceWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        // Schedule periodic updates when the first widget is added
+        scheduleWidgetUpdates(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        // Cancel updates when the last widget is removed
+        cancelWidgetUpdates(context)
+    }
+
+    companion object {
+        private const val WIDGET_UPDATE_WORK = "moe_memos_widget_update_work"
+
+        fun scheduleWidgetUpdates(context: Context) {
+            val updateRequest = PeriodicWorkRequestBuilder<WidgetUpdateWorker>(
+                30, TimeUnit.MINUTES
+            ).build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WIDGET_UPDATE_WORK,
+                ExistingPeriodicWorkPolicy.KEEP,
+                updateRequest
+            )
+        }
+
+        fun cancelWidgetUpdates(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WIDGET_UPDATE_WORK)
+        }
+    }
+
+    /**
+     * Worker class to update the widget periodically
+     */
+    class WidgetUpdateWorker(
+        private val appContext: Context,
+        workerParams: WorkerParameters
+    ) : CoroutineWorker(appContext, workerParams) {
+        override suspend fun doWork(): Result {
+            // Update all instances of the widget
+            val manager = GlanceAppWidgetManager(appContext)
+            val glanceIds = manager.getGlanceIds(MoeMemosGlanceWidget::class.java)
+            glanceIds.forEach { glanceId ->
+                MoeMemosGlanceWidget().update(appContext, glanceId)
+            }
+            return Result.success()
+        }
+    }
+}

--- a/app/src/main/java/me/mudkip/moememos/widget/WidgetEntryPoint.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/WidgetEntryPoint.kt
@@ -1,0 +1,12 @@
+package me.mudkip.moememos.widget
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import me.mudkip.moememos.data.service.MemoService
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WidgetEntryPoint {
+    fun memoService(): MemoService
+}

--- a/app/src/main/java/me/mudkip/moememos/widget/WidgetUpdater.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/WidgetUpdater.kt
@@ -1,0 +1,29 @@
+package me.mudkip.moememos.widget
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Utility class to update all widget instances when memos are changed
+ */
+object WidgetUpdater {
+    /**
+     * Update all widget instances
+     */
+    fun updateWidgets(context: Context) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val manager = GlanceAppWidgetManager(context)
+            val glanceIds = manager.getGlanceIds(MoeMemosGlanceWidget::class.java)
+            
+            // Only update if there are widgets
+            if (glanceIds.isNotEmpty()) {
+                glanceIds.forEach { glanceId ->
+                    MoeMemosGlanceWidget().update(context, glanceId)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_pin.xml
+++ b/app/src/main/res/drawable/ic_pin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
+</vector>

--- a/app/src/main/res/drawable/widget_card_background.xml
+++ b/app/src/main/res/drawable/widget_card_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#424242" /> <!-- Dark gray color for card background -->
+</shape>

--- a/app/src/main/res/drawable/widget_card_pinned_background.xml
+++ b/app/src/main/res/drawable/widget_card_pinned_background.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#424242" /> <!-- Dark gray color for card background -->
+    <stroke android:width="1dp" android:color="#3F51B5" /> <!-- Primary color for border -->
+</shape>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,4 +70,9 @@
     <string name="accounts">Accounts</string>
     <string name="account_detail">Account Detail</string>
     <string name="switch_account">Switch Account</string>
+    
+    <!-- Widget strings -->
+    <string name="loading">Loading…</string>
+    <string name="error_unknown">Unknown error</string>
+    <string name="no_memos">No memos found</string>
 </resources>

--- a/app/src/main/res/xml/moe_memos_glance_widget_info.xml
+++ b/app/src/main/res/xml/moe_memos_glance_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@android:layout/simple_list_item_1"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/app_name" />


### PR DESCRIPTION
Hey all, first time contributor and would appreciate any criticism/feedback as I'm new to Kotlin though I have some experience with flutter not sure if I went about this the right way!

This is an attempt to add some initial widget (via jetpack glance) support to close #41. This is only possible due to the awesome foundational work to support local mode (#4) by @jkuhlemann.

### Summary:
1. I used cline + Claude a bit along the way so I added some clinerules that I added to the ignore
2. I also use [just](https://github.com/casey/just) runner to stream line some dev ex scripts, let me know if you'd like me to ignore it!
3. I added a WidgetUpdater that could be used to force updates on the widget, again not sure if this is the standard for glance but it seemed logical to force push updates to the glance widgets in certain scenarios.
4. I ran into a linter error on `main` from here that I resolved by removing the override, not sure if that was an environment issue or what

### Screenshots

| Light Mode | Dark Mode | Truncation |
| ------------- | ------------- |  ------------- |
| <img width="375" alt="image" src="https://github.com/user-attachments/assets/24d254a9-c53c-40f2-a3d1-9e268e87c0ba" />  | <img width="375" alt="image" src="https://github.com/user-attachments/assets/aae362f1-296a-4c29-b4be-6d0e79e9bd00" />  | <img width="375" alt="image" src="https://github.com/user-attachments/assets/c20a0b3d-8b54-416c-a532-bbed6a15ddc2" /> |
