### PR TITLE
fix: memo copy link broken and memo refreshing never ending

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/data/model/Account.kt
+++ b/app/src/main/java/me/mudkip/moememos/data/model/Account.kt
@@ -13,6 +13,12 @@ sealed class Account {
         Local -> UserData.newBuilder().setAccountKey(accountKey()).setLocal(LocalAccount.getDefaultInstance()).build()
     }
 
+    fun getAccountInfo(): MemosAccount? = when (this) {
+        is MemosV0 -> this.info
+        is MemosV1 -> this.info
+        else -> null
+    }
+
     companion object {
         fun parseUserData(userData: UserData): Account? = when (userData.accountCase) {
             UserData.AccountCase.MEMOS_V0 -> MemosV0(userData.memosV0)

--- a/app/src/main/java/me/mudkip/moememos/ext/MemoExt.kt
+++ b/app/src/main/java/me/mudkip/moememos/ext/MemoExt.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.ui.graphics.vector.ImageVector
 import me.mudkip.moememos.R
-import me.mudkip.moememos.data.model.Memo
 import me.mudkip.moememos.data.model.MemoVisibility
 
 val MemoVisibility.icon: ImageVector get() = when (this) {
@@ -19,8 +18,4 @@ val MemoVisibility.titleResource: Int get() = when (this) {
     MemoVisibility.PRIVATE -> R.string.memo_visibility_private
     MemoVisibility.PROTECTED -> R.string.memo_visibility_protected
     MemoVisibility.PUBLIC -> R.string.memo_visibility_public
-}
-
-fun Memo.getFullLink(host: String): String {
-    return "${host}/m/${identifier}"
 }

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -49,7 +49,6 @@ import com.skydoves.sandwich.suspendOnSuccess
 import kotlinx.coroutines.launch
 import me.mudkip.moememos.R
 import me.mudkip.moememos.data.model.Memo
-import me.mudkip.moememos.ext.getFullLink
 import me.mudkip.moememos.ext.icon
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ext.titleResource
@@ -62,7 +61,6 @@ import me.mudkip.moememos.viewmodel.LocalUserState
 fun MemosCard(
     memo: Memo,
     onEdit: (Memo) -> Unit,
-    host: String? = null,
     previewMode: Boolean = false
 ) {
     val memosViewModel = LocalMemos.current
@@ -115,7 +113,7 @@ fun MemosCard(
                         )
                     }
                     Spacer(modifier = Modifier.weight(1f))
-                    MemosCardActionButton(memo, host)
+                    MemosCardActionButton(memo)
                 }
 
                 MemoContent(
@@ -145,7 +143,6 @@ fun MemosCard(
 @Composable
 fun MemosCardActionButton(
     memo: Memo,
-    host: String? = null,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -222,25 +219,26 @@ fun MemosCardActionButton(
                         contentDescription = null
                     )
                 })
-            host?.let {
-                DropdownMenuItem(
-                    text = { Text(R.string.copy_link.string) },
-                    onClick = {
+            DropdownMenuItem(
+                text = { Text(R.string.copy_link.string) },
+                onClick = {
+                    memosViewModel.host.value?.let { host ->
+                        val memoUrl = "$host/${memo.identifier}"
                         val sendIntent = Intent().apply {
                             action = Intent.ACTION_SEND
-                            putExtra(Intent.EXTRA_TEXT, memo.getFullLink(host))
+                            putExtra(Intent.EXTRA_TEXT, memoUrl)
                             type = "text/plain"
                         }
-                        val shareIntent = Intent.createChooser(sendIntent, "Copy Link")
+                        val shareIntent = Intent.createChooser(sendIntent, null)
                         context.startActivity(shareIntent)
-                    },
-                    leadingIcon = {
-                        Icon(
-                            Icons.Outlined.Link,
-                            contentDescription = null
-                        )
-                    })
-            }
+                    }
+                },
+                leadingIcon = {
+                    Icon(
+                        Icons.Outlined.Link,
+                        contentDescription = null
+                    )
+                })
             DropdownMenuItem(
                 text = { Text(R.string.archive.string) },
                 onClick = {

--- a/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
@@ -84,7 +84,6 @@ fun MemosList(
             items(filteredMemos, key = { it.identifier }) { memo ->
                 MemosCard(
                     memo = memo,
-                    host = viewModel.host,
                     onEdit = { selectedMemo ->
                         navController.navigate("${RouteName.EDIT}?memoId=${selectedMemo.identifier}")
                     },


### PR DESCRIPTION
Hi, I was testing the app after a while of not using it and noticed right away that refreshing the memo list by swiping down in the main screen didn't ever finish, so I looked into the code to find out the cause.

It seems like the implementation for copying links for memos relied on collecting updates of the `currentAccount` variable at the AccountService to find out the host for the current account. However, using `.collect{}` with DataStore.data (the underlaying structure `currentAccount` gets its value from) may never finish, as it suspends for every update in the store, impeding the `loadMemos()` function in the view model from finishing, by trying to load the host each time the memo list was loaded.
I saw the recommended way was to use `.first()` with `runBlocking{}` if needed, but thought using a StateFlow tied to the lifecycle of the view model may be better to keep the latest value loaded (though it shouldn't change unless the current account was switched). This way I also avoided deeply passing the host to each card, and instead reading it from the view model (to avoid injecting the AccountService to each card). Not sure if this is the best decision though, but as the list view model was already referenced and frequently used in each card, thought it would be better this way. 

I also noticed that the link generated was formed with the format `${host}/m/${identifier}` which was invalid from what I tested with the latest version v0.24.4 of memos. Therefore, I changed it to just use `${host}/${memo.identifier}`, after reading the API v1 docs. I'm not sure if I may be breaking compatibility with the v0 API, but the docs I could find of that weren't clear enough about the format of the identifiers, and any mention I could find of it was accompanied by a strong encouragement to use API v1, so please let me know if I need to make any changes.