### PR TITLE
Fixed the background color issue of Glance cards

### DIFF
--- a/app/src/main/res/drawable/widget_card_background.xml
+++ b/app/src/main/res/drawable/widget_card_background.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="16dp" />
-    <solid android:color="#424242" /> <!-- Dark gray color for card background -->
+    <solid android:color="?android:attr/colorBackground" /> <!-- Use theme background color -->
 </shape>

--- a/app/src/main/res/drawable/widget_card_pinned_background.xml
+++ b/app/src/main/res/drawable/widget_card_pinned_background.xml
@@ -1,6 +1,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="16dp" />
-    <solid android:color="#424242" /> <!-- Dark gray color for card background -->
-    <stroke android:width="1dp" android:color="#3F51B5" /> <!-- Primary color for border -->
+    <solid android:color="?android:attr/colorBackground" /> <!-- Use theme background color -->
+    <stroke android:width="1dp" android:color="?android:attr/colorPrimary" /> <!-- Primary color for border -->
 </shape>


### PR DESCRIPTION
The previous gray background looked terrible under the light theme, so I modified the Drawable resource to use the theme color.