### PR TITLE
Fix typo in German translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -8,7 +8,7 @@
     <string name="new_memo">Neue Notiz</string>
     <string name="compose">Verfassen</string>
     <string name="remove">Entfernen</string>
-    <string name="resources">Resourcen</string>
+    <string name="resources">Ressourcen</string>
     <string name="archived">Archiviert</string>
     <string name="settings">Einstellungen</string>
     <string name="tags">Hashtags</string>


### PR DESCRIPTION
Corrected the spelling of "Ressourcen" in strings.xml. Just a small fix I noticed while using the app. :)