### PR TITLE
feat: Configurable Quick-Edit

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/data/model/UserSettings.kt
+++ b/app/src/main/java/me/mudkip/moememos/data/model/UserSettings.kt
@@ -3,7 +3,16 @@ package me.mudkip.moememos.data.model
 import kotlinx.serialization.Serializable
 
 @Serializable
+enum class MemoEditGesture {
+    NONE,
+    SINGLE,
+    DOUBLE,
+    LONG,
+}
+
+@Serializable
 data class UserSettings(
     val draft: String = "",
     val acceptedUnsupportedSyncVersions: List<String> = emptyList(),
+    val editGesture: MemoEditGesture = MemoEditGesture.NONE,
 )

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
 import android.text.format.DateUtils
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +52,7 @@ import kotlinx.coroutines.launch
 import me.mudkip.moememos.R
 import me.mudkip.moememos.data.local.entity.MemoEntity
 import me.mudkip.moememos.data.model.Account
+import me.mudkip.moememos.data.model.MemoEditGesture
 import me.mudkip.moememos.ext.icon
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ext.titleResource
@@ -63,18 +65,44 @@ import me.mudkip.moememos.viewmodel.LocalUserState
 fun MemosCard(
     memo: MemoEntity,
     onClick: (MemoEntity) -> Unit,
+    editGesture: MemoEditGesture = MemoEditGesture.NONE,
     previewMode: Boolean = false,
     showSyncStatus: Boolean = false,
     onTagClick: ((String) -> Unit)? = null
 ) {
     val memosViewModel = LocalMemos.current
+    val rootNavController = LocalRootNavController.current
     val scope = rememberCoroutineScope()
 
+    val cardModifier = Modifier
+        .padding(horizontal = 15.dp, vertical = 10.dp)
+        .fillMaxWidth()
+        .combinedClickable(
+            onClick = {
+                if (editGesture == MemoEditGesture.SINGLE) {
+                    rootNavController.navigate("${RouteName.EDIT}?memoId=${memo.identifier}")
+                } else {
+                    onClick(memo)
+                }
+            },
+            onLongClick = if (editGesture == MemoEditGesture.LONG) {
+                {
+                    rootNavController.navigate("${RouteName.EDIT}?memoId=${memo.identifier}")
+                }
+            } else {
+                null
+            },
+            onDoubleClick = if (editGesture == MemoEditGesture.DOUBLE) {
+                {
+                    rootNavController.navigate("${RouteName.EDIT}?memoId=${memo.identifier}")
+                }
+            } else {
+                null
+            }
+        )
+
     Card(
-        onClick = { onClick(memo) },
-        modifier = Modifier
-            .padding(horizontal = 15.dp, vertical = 10.dp)
-            .fillMaxWidth(),
+        modifier = cardModifier,
         border = if (memo.pinned) {
             BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
         } else {

--- a/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/memos/MemosList.kt
@@ -24,9 +24,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.launch
 import me.mudkip.moememos.R
 import me.mudkip.moememos.data.model.Account
+import me.mudkip.moememos.data.model.MemoEditGesture
+import me.mudkip.moememos.data.model.Settings
+import me.mudkip.moememos.ext.settingsDataStore
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ui.component.MemosCard
 import me.mudkip.moememos.ui.page.common.LocalRootNavController
@@ -46,10 +50,16 @@ fun MemosList(
     onRefresh: (suspend () -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
 ) {
+    val context = LocalContext.current
     val navController = LocalRootNavController.current
     val viewModel = LocalMemos.current
     val userStateViewModel = LocalUserState.current
     val currentAccount by userStateViewModel.currentAccount.collectAsState()
+    val settings by context.settingsDataStore.data.collectAsState(initial = Settings())
+    val editGesture = settings.usersList
+        .firstOrNull { it.accountKey == settings.currentUser }
+        ?.settings
+        ?.editGesture
     val refreshState = rememberPullToRefreshState()
     val scope = rememberCoroutineScope()
     var isRefreshing by remember { mutableStateOf(false) }
@@ -119,6 +129,7 @@ fun MemosList(
                             "${RouteName.MEMO_DETAIL}?memoId=${Uri.encode(selectedMemo.identifier)}"
                         )
                     },
+                    editGesture = editGesture ?: MemoEditGesture.NONE,
                     previewMode = true,
                     showSyncStatus = currentAccount !is Account.Local,
                     onTagClick = onTagClick

--- a/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
@@ -7,11 +7,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.Source
 import androidx.compose.material.icons.outlined.Web
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -19,19 +21,30 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import me.mudkip.moememos.R
 import me.mudkip.moememos.data.model.Account
+import me.mudkip.moememos.data.model.MemoEditGesture
+import me.mudkip.moememos.data.model.Settings
 import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
+import me.mudkip.moememos.ext.settingsDataStore
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ui.component.MemosIcon
 import me.mudkip.moememos.ui.page.common.RouteName
@@ -45,9 +58,18 @@ fun SettingsPage(
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val userStateViewModel = LocalUserState.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val scope = rememberCoroutineScope()
     val accounts by userStateViewModel.accounts.collectAsState()
     val currentAccount by userStateViewModel.currentAccount.collectAsState()
+    val settings by context.settingsDataStore.data.collectAsState(initial = Settings())
+    var showEditGestureDialog by remember { mutableStateOf(false) }
+    val currentEditGesture = settings.usersList
+        .firstOrNull { it.accountKey == settings.currentUser }
+        ?.settings
+        ?.editGesture
+        ?: MemoEditGesture.NONE
 
     Scaffold(
         modifier = Modifier
@@ -129,6 +151,21 @@ fun SettingsPage(
             }
 
             item {
+                SettingItem(
+                    icon = Icons.Outlined.Edit,
+                    text = R.string.edit_gesture.string,
+                    trailingIcon = {
+                        Text(
+                            text = currentEditGesture.titleResource.string,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                ) {
+                    showEditGestureDialog = true
+                }
+            }
+
+            item {
                 Text(
                     R.string.about.string,
                     modifier = Modifier
@@ -164,4 +201,63 @@ fun SettingsPage(
             }
         }
     }
+
+    if (showEditGestureDialog) {
+        AlertDialog(
+            onDismissRequest = { showEditGestureDialog = false },
+            title = { Text(R.string.edit_gesture.string) },
+            text = {
+                LazyColumn {
+                    items(MemoEditGesture.entries.size) { index ->
+                        val gesture = MemoEditGesture.entries[index]
+                        TextButton(
+                            onClick = {
+                                showEditGestureDialog = false
+                                scope.launch(Dispatchers.IO) {
+                                    context.settingsDataStore.updateData { existingSettings ->
+                                        val userIndex = existingSettings.usersList.indexOfFirst { user ->
+                                            user.accountKey == existingSettings.currentUser
+                                        }
+                                        if (userIndex == -1) {
+                                            return@updateData existingSettings
+                                        }
+                                        val users = existingSettings.usersList.toMutableList()
+                                        val user = users[userIndex]
+                                        users[userIndex] = user.copy(
+                                            settings = user.settings.copy(editGesture = gesture)
+                                        )
+                                        existingSettings.copy(usersList = users)
+                                    }
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = gesture.titleResource.string,
+                                color = if (gesture == currentEditGesture) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showEditGestureDialog = false }) {
+                    Text(R.string.close.string)
+                }
+            }
+        )
+    }
 }
+
+private val MemoEditGesture.titleResource: Int
+    get() = when (this) {
+        MemoEditGesture.NONE -> R.string.edit_gesture_none
+        MemoEditGesture.SINGLE -> R.string.edit_gesture_single
+        MemoEditGesture.DOUBLE -> R.string.edit_gesture_double
+        MemoEditGesture.LONG -> R.string.edit_gesture_long
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,11 @@
     <string name="sync_status_unsynced">Unsynced changes</string>
     <string name="memo_sync_pending">Memo not synced</string>
     <string name="memo_sync_synced">Memo synced</string>
+    <string name="edit_gesture">Edit gesture</string>
+    <string name="edit_gesture_none">None</string>
+    <string name="edit_gesture_single">Single tap</string>
+    <string name="edit_gesture_double">Double tap</string>
+    <string name="edit_gesture_long">Long tap</string>
     <string name="failed_to_open_attachment">Failed to open attachment</string>
     <string name="export_local_account">Export Local Data</string>
     <string name="local_export_success">Local data exported</string>


### PR DESCRIPTION
This adds a quick-edit feature (requested in #292) and a setting to configure said feature. Either "none", the current behavior and default setting or single, double or long tap.

I would greatly appreciate this feature too (therefore this PR).

This PR was partially made with AI. All code has been reviewed to the best of my (limited) android knowledge and tested as working.

Screenshots:
<img width="421" height="935" alt="{CE40F9DF-0C00-44B6-A224-F60E3B9A2AC7}" src="https://github.com/user-attachments/assets/af0d9bc4-f19c-4afc-bd41-a9f7c7ec5e08" />

<img width="435" height="926" alt="{814E09D7-8F37-4205-B711-3FB9FBA1A6A6}" src="https://github.com/user-attachments/assets/b5d3adf3-50c8-43a3-9b07-b6cdd929aaa8" />

<img width="453" height="936" alt="{B4769096-DB84-4F19-8ECF-5C1C7491DD31}" src="https://github.com/user-attachments/assets/dd95c63d-be32-4308-b060-5cb4e15376ae" />
