### PR TITLE
feat: improve home screen widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,15 @@
             <meta-data android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+
+        <activity
+            android:name=".widget.MeoMemosGlanceWidgetConfigurationActivity"
+            android:exported="true"
+            android:theme="@style/Theme.MoeMemos">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
         
         <provider
             android:authorities="me.mudkip.moememos.fileprovider"

--- a/app/src/main/java/me/mudkip/moememos/widget/MeoMemosGlanceWidgetConfigurationActivity.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/MeoMemosGlanceWidgetConfigurationActivity.kt
@@ -1,0 +1,263 @@
+package me.mudkip.moememos.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.Preferences
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.lifecycle.lifecycleScope
+import com.skydoves.sandwich.suspendOnSuccess
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import me.mudkip.moememos.R
+import me.mudkip.moememos.data.service.MemoService
+import me.mudkip.moememos.ui.theme.MoeMemosTheme
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MeoMemosGlanceWidgetConfigurationActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var memoService: MemoService
+
+    private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        appWidgetId = intent?.extras?.getInt(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        val resultValue = Intent().apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        }
+        setResult(RESULT_CANCELED, resultValue)
+
+        setContent {
+            MoeMemosTheme {
+                ConfigurationScreen()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+    @Composable
+    fun ConfigurationScreen() {
+        var selectedTag by remember { mutableStateOf<String?>(null) }
+        var pinnedOnly by remember { mutableStateOf(false) }
+        var maxItems by remember { mutableFloatStateOf(10f) }
+        var tags by remember { mutableStateOf<List<String>>(emptyList()) }
+        var isLoading by remember { mutableStateOf(true) }
+
+        LaunchedEffect(Unit) {
+            try {
+                // Fetch tags
+                val result = memoService.getRepository().listTags()
+                result.suspendOnSuccess {
+                    tags = data
+                }
+
+                // Fetch current preferences
+                val glanceId = GlanceAppWidgetManager(this@MeoMemosGlanceWidgetConfigurationActivity)
+                    .getGlanceIdBy(appWidgetId)
+                val prefs = getAppWidgetState(
+                    context = this@MeoMemosGlanceWidgetConfigurationActivity,
+                    definition = PreferencesGlanceStateDefinition,
+                    glanceId = glanceId
+                )
+                
+                selectedTag = prefs[MoeMemosWidgetKeys.filterTag]
+                pinnedOnly = prefs[MoeMemosWidgetKeys.pinnedOnly] ?: false
+                maxItems = (prefs[MoeMemosWidgetKeys.maxItems] ?: 10).toFloat()
+            } catch (e: Exception) {
+                // Ignore error
+            } finally {
+                isLoading = false
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.preferences)) },
+                    navigationIcon = {
+                        IconButton(onClick = { finish() }) {
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cancel))
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { saveConfig(selectedTag, pinnedOnly, maxItems.toInt()) }) {
+                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.confirm))
+                        }
+                    }
+                )
+            }
+        ) { padding ->
+            if (isLoading) {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .padding(16.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                ) {
+                    // Tag Selection
+                    Column {
+                        Text(
+                            text = stringResource(R.string.filter_by_tag),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            FilterChip(
+                                selected = selectedTag == null,
+                                onClick = { selectedTag = null },
+                                label = { Text("None") }
+                            )
+                            tags.forEach { tag ->
+                                FilterChip(
+                                    selected = selectedTag == tag,
+                                    onClick = { selectedTag = tag },
+                                    label = { Text("#$tag") }
+                                )
+                            }
+                        }
+                    }
+
+                    // Pinned Only
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = stringResource(R.string.pinned_only),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Switch(
+                            checked = pinnedOnly,
+                            onCheckedChange = { pinnedOnly = it }
+                        )
+                    }
+
+                    // Max Items
+                    Column {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = "Max Items",
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                text = maxItems.toInt().toString(),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        }
+                        Slider(
+                            value = maxItems,
+                            onValueChange = { maxItems = it },
+                            valueRange = 1f..30f,
+                            steps = 28
+                        )
+                    }
+                    
+                    Spacer(modifier = Modifier.weight(1f))
+                    
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { saveConfig(selectedTag, pinnedOnly, maxItems.toInt()) }
+                    ) {
+                        Text(stringResource(R.string.confirm))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun saveConfig(filterTag: String?, pinnedOnly: Boolean, maxItems: Int) {
+        lifecycleScope.launch {
+            val glanceId = GlanceAppWidgetManager(this@MeoMemosGlanceWidgetConfigurationActivity)
+                .getGlanceIdBy(appWidgetId)
+            
+            updateAppWidgetState(this@MeoMemosGlanceWidgetConfigurationActivity, glanceId) { prefs ->
+                if (filterTag != null) {
+                    prefs[MoeMemosWidgetKeys.filterTag] = filterTag
+                } else {
+                    prefs.remove(MoeMemosWidgetKeys.filterTag)
+                }
+                prefs[MoeMemosWidgetKeys.pinnedOnly] = pinnedOnly
+                prefs[MoeMemosWidgetKeys.maxItems] = maxItems
+            }
+            
+            MoeMemosGlanceWidget().update(this@MeoMemosGlanceWidgetConfigurationActivity, glanceId)
+            
+            val resultValue = Intent().apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            setResult(RESULT_OK, resultValue)
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
+++ b/app/src/main/java/me/mudkip/moememos/widget/MoeMemosGlanceWidget.kt
@@ -11,17 +11,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.action.ActionParameters
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.itemsIndexed
 import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.background
+import androidx.glance.currentState
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
@@ -33,6 +45,7 @@ import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
+import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -49,35 +62,51 @@ import java.time.Instant
 
 class MoeMemosGlanceWidget : GlanceAppWidget() {
 
+    override val stateDefinition = PreferencesGlanceStateDefinition
+
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val widgetEntryPoint = EntryPointAccessors.fromApplication(
             context.applicationContext,
             WidgetEntryPoint::class.java
         )
         val memoService = widgetEntryPoint.memoService()
-        
+
         provideContent {
+            val prefs = currentState<Preferences>()
             GlanceTheme {
-                WidgetContent(context, memoService)
+                WidgetContent(context, memoService, prefs)
             }
         }
     }
 
     @Composable
-    private fun WidgetContent(context: Context, memoService: MemoService) {
+    private fun WidgetContent(context: Context, memoService: MemoService, prefs: Preferences) {
         var memos by remember { mutableStateOf<List<MemoEntity>>(emptyList()) }
         var isLoading by remember { mutableStateOf(true) }
         var error by remember { mutableStateOf<String?>(null) }
 
-        LaunchedEffect(Unit) {
+        val filterTag = prefs[MoeMemosWidgetKeys.filterTag]
+        val pinnedOnly = prefs[MoeMemosWidgetKeys.pinnedOnly] ?: false
+        val maxItems = prefs[MoeMemosWidgetKeys.maxItems] ?: 10
+        val refreshKey = prefs[MoeMemosWidgetKeys.refreshKey] ?: 0L
+
+        LaunchedEffect(filterTag, pinnedOnly, maxItems, refreshKey) {
             withContext(Dispatchers.IO) {
                 try {
+                    isLoading = true
                     memoService.getRepository().listMemos().suspendOnSuccess {
-                        // Get pinned memos first, then most recent
-                        val sortedMemos = data.sortedWith(
+                        // Filter and sort memos
+                        val filteredMemos = data.filter { memo ->
+                            val matchesTag = filterTag == null || memo.content.contains("#$filterTag")
+                            val matchesPinned = !pinnedOnly || memo.pinned
+                            matchesTag && matchesPinned
+                        }
+                        
+                        val sortedMemos = filteredMemos.sortedWith(
                             compareByDescending<MemoEntity> { it.pinned }
                                 .thenByDescending { it.date }
-                        ).take(3)
+                        ).take(maxItems)
+                        
                         memos = sortedMemos
                         error = null
                     }
@@ -109,15 +138,41 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
                     modifier = GlanceModifier.size(24.dp)
                 )
                 Spacer(modifier = GlanceModifier.width(8.dp))
-                Text(
-                    text = context.getString(R.string.memos),
-                    style = TextStyle(
-                        color = GlanceTheme.colors.primary,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold
+                Column {
+                    Text(
+                        text = context.getString(R.string.memos),
+                        style = TextStyle(
+                            color = GlanceTheme.colors.primary,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold
+                        )
                     )
-                )
+                    if (filterTag != null) {
+                        Text(
+                            text = "#$filterTag",
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onSurfaceVariant,
+                                fontSize = 12.sp
+                            )
+                        )
+                    }
+                }
                 Spacer(modifier = GlanceModifier.defaultWeight())
+                // Refresh button
+                Box(
+                    modifier = GlanceModifier
+                        .size(36.dp)
+                        .clickable(actionRunCallback<RefreshAction>())
+                        .padding(4.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        provider = ImageProvider(R.drawable.ic_shortcut_refresh),
+                        contentDescription = context.getString(R.string.refresh),
+                        modifier = GlanceModifier.size(24.dp)
+                    )
+                }
+                Spacer(modifier = GlanceModifier.width(8.dp))
                 // Add new memo button
                 Box(
                     modifier = GlanceModifier
@@ -172,12 +227,14 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
                     }
                 }
                 else -> {
-                    Column(
-                        modifier = GlanceModifier.fillMaxWidth(),
+                    LazyColumn(
+                        modifier = GlanceModifier.fillMaxSize()
                     ) {
-                        memos.forEachIndexed { index, memo ->
+                        itemsIndexed(memos) { index, memo ->
                             val isLastMemo = index == memos.size - 1
+
                             MemoItem(context, memo, isLastMemo)
+
                             if (!isLastMemo) {
                                 Spacer(modifier = GlanceModifier.height(2.dp))
                             }
@@ -196,7 +253,7 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
                 .fillMaxWidth()
                 .padding(2.dp, 4.dp, 2.dp, if (isLastMemo) 0.dp else 4.dp)
         ) {
-            // Card content with rounded corners
+            // Card content with rounded corners and borders (via XML drawables)
             Column(
                 modifier = GlanceModifier
                     .fillMaxWidth()
@@ -267,6 +324,27 @@ class MoeMemosGlanceWidget : GlanceAppWidget() {
     }
 }
 
+class RefreshAction : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters
+    ) {
+        updateAppWidgetState(context, glanceId) { prefs ->
+            val current = prefs[MoeMemosWidgetKeys.refreshKey] ?: 0L
+            prefs[MoeMemosWidgetKeys.refreshKey] = current + 1
+        }
+        MoeMemosGlanceWidget().update(context, glanceId)
+    }
+}
+
+object MoeMemosWidgetKeys {
+    val filterTag = stringPreferencesKey("filter_tag")
+    val pinnedOnly = booleanPreferencesKey("pinned_only")
+    val maxItems = intPreferencesKey("max_items")
+    val refreshKey = longPreferencesKey("refresh_key")
+}
+
 private fun createOpenAppIntent(context: Context): Intent =
     Intent(context, MainActivity::class.java).apply {
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -277,6 +355,7 @@ private fun createNewMemoIntent(context: Context): Intent =
         action = MainActivity.ACTION_NEW_MEMO
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
     }
+
 
 private fun createViewMemoIntent(context: Context, memoId: String): Intent =
     Intent(context, MainActivity::class.java).apply {

--- a/app/src/main/res/drawable/ic_shortcut_refresh.xml
+++ b/app/src/main/res/drawable/ic_shortcut_refresh.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#f3cf63"
+        android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"/>
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/drawable/widget_card_background.xml
+++ b/app/src/main/res/drawable/widget_card_background.xml
@@ -2,4 +2,5 @@
     android:shape="rectangle">
     <corners android:radius="16dp" />
     <solid android:color="?android:attr/colorBackground" /> <!-- Use theme background color -->
+    <stroke android:width="1dp" android:color="?android:attr/textColorPrimaryInverse" /> <!-- Less visible dark color -->
 </shape>

--- a/app/src/main/res/drawable/widget_card_pinned_background.xml
+++ b/app/src/main/res/drawable/widget_card_pinned_background.xml
@@ -2,5 +2,5 @@
     android:shape="rectangle">
     <corners android:radius="16dp" />
     <solid android:color="?android:attr/colorBackground" /> <!-- Use theme background color -->
-    <stroke android:width="1dp" android:color="?android:attr/colorPrimary" /> <!-- Primary color for border -->
+    <stroke android:width="1dp" android:color="?android:attr/textColorPrimary" /> <!-- More visible bright color -->
 </shape>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,4 +105,8 @@
     <string name="error_unknown">Unbekannter Fehler</string>
     <string name="no_memos">Keine Memos gefunden</string>
     <string name="memo_not_found">Memo nicht gefunden</string>
+    <string name="filter_by_tag">Filtern nach Hahstag</string>
+    <string name="pinned_only">Nur angepinnte anzeigen</string>
+    <string name="max_items">Maximale anzahl Elemente</string>
+    <string name="refresh">Aktualisieren</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,4 +113,8 @@
     <string name="error_unknown">Unknown error</string>
     <string name="no_memos">No memos found</string>
     <string name="memo_not_found">Memo not found</string>
+    <string name="filter_by_tag">Filter by tag</string>
+    <string name="pinned_only">Show only pinned items.</string>
+    <string name="max_items">Maximum items to show</string>
+    <string name="refresh">Refresh</string>
 </resources>

--- a/app/src/main/res/xml/moe_memos_glance_widget_info.xml
+++ b/app/src/main/res/xml/moe_memos_glance_widget_info.xml
@@ -6,4 +6,6 @@
     android:initialLayout="@android:layout/simple_list_item_1"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
+    android:configure="me.mudkip.moememos.widget.MeoMemosGlanceWidgetConfigurationActivity"
+    android:widgetFeatures="reconfigurable|configuration_optional"
     android:description="@string/app_name" />


### PR DESCRIPTION
This PR enhances the functionality of the home screen widget. 
- The number of items displayed has been increased.
- Scrolling has been added if it does not fit into the frame.
- Filtering by hashtag has been added.
- A manual refresh button has been added.
- Added a widget configuration activity to set the hashtag filter, show only pinned items and set the maximum number of items to show.

Only English and German translations are available. The others are missing.

This PR was partially created using AI. All code has been reviewed and tested to ensure it works.

<img width="540" height="815" alt="image" src="https://github.com/user-attachments/assets/74d2a61a-8a06-4fe4-8175-dbd67fe0b570" />

<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/7964bdf5-9603-423c-be64-a2099d561987" />

[Screen_recording_20260331_090752.webm](https://github.com/user-attachments/assets/15c9f5e1-9ae4-4def-abe5-5369a529f1f4)

